### PR TITLE
Simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,8 @@
   "version": "0.3.1",
   "description": "Jekyll-like blog engine for node.js",
   "author": "Filipe Fortes <filipe@fortes.com>",
-  "contributors": [
-    "Filipe Fortes"
-  ],
-  "homepage": "https://github.com/fortes/enfield",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/fortes/enfield.git"
-  },
-  "bugs": {
-    "url": "https://github.com/fortes/enfield/issues"
-  },
+  "repository": "fortes/enfield",
   "keywords": [
     "blog",
     "static",
@@ -22,9 +12,9 @@
     "jekyll"
   ],
   "files": [
+    "bin",
     "CHANGELOG.md",
     "LICENSE",
-    "bin",
     "site_template",
     "src"
   ],


### PR DESCRIPTION
- `contributors` is redundant if its only value is same as `author` (like it is now).
- Simplify `repository` property.
- npm auto-generates `homepage` and `bugs` per `repository`.
