### PR TITLE
Add `.mkdown` as valid Markdown extension

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -70,7 +70,7 @@ module.exports = exports =
     paginate_path: "page:num"
 
     #markdown: "maruku"
-    markdown_ext: ["markdown", "mkd", "mkdn", "md"]
+    markdown_ext: ["markdown", "mkdown", "mkdn", "mkd", "md"]
     #textile_ext: ["textile"]
 
     excerpt_separator: "\n\n"


### PR DESCRIPTION
Per https://github.com/jekyll/jekyll/commit/699066ef85be89d8ee018c87466a9be9ebc4b0c7.
