### PR TITLE
update time module dependency to 0.11 to support node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npmlog": "~0.0",
     "pygments": "~0.2",
     "q": "~1.0",
-    "time": "~0.10",
+    "time": "~0.11.0",
     "tinyliquid": "~0.2",
     "toposort": "~0.2",
     "uglify-js": "~2.4",


### PR DESCRIPTION
The time module Enfield depends on doesn't compile under Node 0.12. This bumps the version up and things install properly again.