### PR TITLE
Remove time dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "npmlog": "~1.2",
     "pygments": "~0.2",
     "q": "~1.2",
-    "time": "~0.11",
     "tinyliquid": "~0.2",
     "toposort": "~0.2",
     "uglify-js": "~2.4",

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,7 +1,6 @@
 fs   = require "fs"
 log  = require "./log"
 path = require "path"
-time = require "time"
 Q    = require "q"
 yaml = require "js-yaml"
 
@@ -109,7 +108,7 @@ resolveOptions = (config) ->
 
   unless config.timezone
     # Use system default
-    config.timezone = time.currentTimezone
+    config.timezone = new Date().getTimezoneOffset()
 
   # Make source, config, and destination paths relative to current directory
   config.source = path.relative process.cwd(), config.source

--- a/src/generate.coffee
+++ b/src/generate.coffee
@@ -4,7 +4,6 @@ gaze       = require "gaze"
 glob       = require "glob"
 log        = require "./log"
 path       = require "path"
-time       = require("time")(Date) # Extend global object
 tinyliquid = require "tinyliquid"
 toposort   = require "toposort"
 util       = require "util"
@@ -25,7 +24,7 @@ module.exports = exports = (config) ->
   log.info "generate", "Begin generation"
   # First-run initialization
   postMask = ///^(\d{4})-(\d{2})-(\d{2})-(.+)\.(#{config.markdown_ext.join "|"}|html)$///
-  time.tzset config.timezone
+  # time.tzset config.timezone
   Q.all([checkDirectories(config), loadBundledPlugins()])
     .then ->
       log.verbose "generate", "Initialization complete"

--- a/test/plugins/jeykll-extensions.coffee
+++ b/test/plugins/jeykll-extensions.coffee
@@ -1,6 +1,5 @@
 assert = require "assert"
 sinon  = require "sinon"
-time   = require "time"
 
 {filters, tags, generators} = require "../../src/plugins/jekyll-extensions"
 


### PR DESCRIPTION
time dep is used for timezone offset.
time is a native module.
Removing the dep, it allows to install enfield without a compiler.

This patch temporary ignores timezones.

See #40.
