### PR TITLE
Remove NODE_ENV from scripts test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "test": "NODE_ENV=test mocha --recursive --reporter tap --compilers coffee:coffee-script/register",
-    "test-watch": "NODE_ENV=test mocha --recursive --watch --reporter dot --compilers coffee:coffee-script/register"
+    "test": "mocha --recursive --reporter tap --compilers coffee:coffee-script/register",
+    "test-watch": "mocha --recursive --watch --reporter dot --compilers coffee:coffee-script/register"
   },
   "dependencies": {
     "async": "~0.9",

--- a/test/config.coffee
+++ b/test/config.coffee
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = "test"
+
 assert = require "assert"
 sinon  = require "sinon"
 

--- a/test/generate.coffee
+++ b/test/generate.coffee
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = "test"
+
 assert = require "assert"
 
 generate = require "../src/generate"


### PR DESCRIPTION
This is useful for Windows environment (see #14).
On Windows "npm test" runs, but a few tests don't pass due to the path.
